### PR TITLE
Use the `v1` tag in sample workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply standard cisagov job preamble
-        uses: cisagov/action-job-preamble@develop
+        uses: cisagov/action-job-preamble@v1
         with:
           actions_permissions_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
 ```


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the documentation to use the `v1` tag in the sample workflow.

## 💭 Motivation and context ##

@mcdonnnj pointed out this omission that should have been taken care of in #1.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.